### PR TITLE
Chore: Update REUSE.toml to cover *.lock

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -8,7 +8,7 @@ path = [
 	 "tests/dist/**",
 	 "img/favicon/**",
 	 "test_coverage_report*",
-         "pdm.lock"
+         "*.lock"
 ]
 
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
Add license coverage for Pipfile.lock, others