### PR TITLE
Fix: linting error/missing starting space in comment

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -67,7 +67,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     needs:
       - python-build
-    # Matrix job
+    # Matrix job
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.python-build.outputs.matrix_json) }}
@@ -103,7 +103,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     needs:
       - python-build
-    # Matrix job
+    # Matrix job
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.python-build.outputs.matrix_json) }}


### PR DESCRIPTION
These look like spaces but aren't and fail linting checks with:
    
Error: 70:6 [comments] missing starting space in comment
Error: 106:6 [comments] missing starting space in comment