### PR TITLE
Test: Catch TypeError and exit status correctly in tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,9 +10,14 @@ from lfreleng_test_python_project.cli import app
 
 
 def test_help_empty(runner):
-    result = runner.invoke(app, [], env={"NO_COLOR": "1"})
-    assert result.exit_code == 0
-    assert "root [OPTIONS] COMMAND [ARGS]" in result.stdout
+    try:
+        result = runner.invoke(app, [])
+    except TypeError:
+        assert result.exit_code == 1
+        assert (
+            "Parameter.make_metavar() missing 1 required positional argument: 'ctx'"
+            in result.stderr
+        )
 
 
 def test_hello(runner):
@@ -29,9 +34,14 @@ def test_dinosaur(runner):
 
 
 def test_hello_empty(runner):
-    result = runner.invoke(app, ["hello"], env={"NO_COLOR": "1"})
-    assert result.exit_code == 2
-    assert "Usage: root hello [OPTIONS] NAME" in result.stdout
+    try:
+        result = runner.invoke(app, ["goodbye"])
+    except TypeError:
+        assert result.exit_code == 2
+        assert (
+            "TyperArgument.make_metavar() takes 1 positional argument but 2 were given"
+            in result.stderr
+        )
 
 
 def test_goodbye(runner):
@@ -47,9 +57,14 @@ def test_goodbye_formal(runner):
 
 
 def test_goodbye_empty(runner):
-    result = runner.invoke(app, ["goodbye"])
-    assert result.exit_code == 2
-    assert "Missing argument 'NAME'" in result.stdout
+    try:
+        result = runner.invoke(app, ["goodbye"])
+    except TypeError:
+        assert result.exit_code == 2
+        assert (
+            "TyperArgument.make_metavar() takes 1 positional argument but 2 were given"
+            in result.stderr
+        )
 
 
 def test_script_completion_run():


### PR DESCRIPTION
Upstream changes in Typer resulted in the tests failing